### PR TITLE
Added RectangleSelector.geometry docstring

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2334,6 +2334,11 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def geometry(self):
+      """
+      Returns numpy.ndarray of shape (2,5) containing x (RectangleSelector.geometry[1:]) 
+      and y (RectangleSelector.geometry[0:]) coordinates of the four corners of the rectangle starting 
+      and ending in the top left corner.
+      """ 
         if hasattr(self.to_draw, 'get_verts'):
             xfm = self.ax.transData.inverted()
             y, x = xfm.transform(self.to_draw.get_verts()).T


### PR DESCRIPTION
Docstring contains details specific to RectangleSelector and does not fully generalize to EllipseSelector.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Added docstring to geometry property of RectangleSelector. EllipseSelector geometry property
returns slightly different information, so this docstring is specific to RectangleSelector.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [ x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [ x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
